### PR TITLE
228 search harbin

### DIFF
--- a/components/forum/SearchBar.jsx
+++ b/components/forum/SearchBar.jsx
@@ -5,12 +5,17 @@ import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import InputLabel from "@mui/material/InputLabel";
 import { useRouter } from 'next/router'
-
+import useDynamicPadding from "../../lib/useDynamicPadding";
+import useClickOutside from "../../lib/useClickOutside";
 const filterData = (query, data) => {
   if (!query) {
     return data;
   } else {
-    return data.filter((d) => d.toLowerCase().includes(query));
+    return data.filter((d) => {
+      const userName = `${d.fname} ${d.lname}`
+      return userName.toLowerCase().includes(query)
+    })
+      ;
   }
 };
 
@@ -50,7 +55,9 @@ const Bar = ({ searchQuery, setSearchQuery }) => {
       variant="outlined"
       placeholder="Search for a profile..."
       size="small"
-      sx={{ width: "40vw" }}
+      sx={{
+        width: "40vw", backgroundColor: "#F5F5F5"
+      }}
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">
@@ -64,10 +71,20 @@ const Bar = ({ searchQuery, setSearchQuery }) => {
     // </form>
   );
 }
-const SearchBar = () => {
+const SearchBar = ({ allAccounts }) => {
   const [searchQuery, setSearchQuery] = useState("");
-  const dataFiltered = filterData(searchQuery, data);
+  const filteredAccounts = filterData(searchQuery, allAccounts) ? filterData(searchQuery, allAccounts) : [];
+  const [isHovered, setHovered] = useState(Array(filteredAccounts.length).fill(false))
 
+  const searchResultsRef = useRef(null)
+  const handleClickOutside = () => {
+    setSearchQuery("")
+  }
+  useClickOutside(searchResultsRef, handleClickOutside)
+
+  useEffect(() => {
+    setHovered(Array(filteredAccounts.length).fill(false))
+  }, [searchQuery])
   return (
     <div
       style={{
@@ -78,24 +95,39 @@ const SearchBar = () => {
       }}
     >
       <Bar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
-      <div style={{ padding: 3 }}>
+      <div ref={searchResultsRef} style={{ position: "absolute", top: 162, left: useDynamicPadding(635, 775, "29vw", "20vw", "15vw"), paddingBottom: 3, maxHeight: "12.5vw", zIndex: 1000 , backgroundColor: "white", overflowY: "auto", width: "40.2vw", borderBottom: "5px solid white" }}>
         {searchQuery &&
-          dataFiltered.map((d) => (
+          filteredAccounts.map((d, index) => (
             <div
               className="text"
               style={{
+                display: "flex",
+                alignItems: "center",
                 padding: 5,
                 justifyContent: "normal",
                 fontSize: 20,
-                color: "blue",
+                color: "black",
                 margin: 1,
-                width: "250px",
-                BorderColor: "green",
-                borderWidth: "10px",
+                width: "99%",
+                border: "1.95px solid #F5F5F5",
+                borderRadius: "5px",
+                cursor: "pointer",
+                backgroundColor: isHovered[index] ? "#F5F5F5" : "white"
               }}
               key={d.id}
+              onMouseEnter={() => setHovered((prev) => {
+                prev[index] = true
+                return [...prev]
+              })}
+              onMouseLeave={() => setHovered((prev) => {
+                prev[index] = false
+                return [...prev]
+              })}
             >
-              {d}
+              <img style={{ height: 25, marginLeft: 15 }} src={d.pfpLink ? d.pfpLink : "https://res.cloudinary.com/alp-portal/image/upload/c_thumb,g_face,h_150,w_150/rzjgu7qrlfhgefei5v4g"} />
+              <p style={{ marginLeft: 18 }}>
+                {`${d.fname} ${d.lname}`}
+              </p>
             </div>
           ))}
       </div>

--- a/components/forum/SearchBar.jsx
+++ b/components/forum/SearchBar.jsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import IconButton from "@mui/material/IconButton";
 import SearchIcon from "@mui/icons-material/Search";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import InputLabel from "@mui/material/InputLabel";
+import { useRouter } from 'next/router'
 
 const filterData = (query, data) => {
   if (!query) {
@@ -26,9 +27,21 @@ const data = [
   "Dublin",
 ];
 
-const Bar = ({ setSearchQuery }) => (
-  <form>
+const Bar = ({ searchQuery, setSearchQuery }) => {
+  const router = useRouter()
+  const handleKeyPress = (event) => {
+    console.log("helloo")
+    if (event.key === 'Enter' && searchQuery !== '') {
+      console.log("we did it")
+      // console.log(router.pathName)
+      router.push(`/profile_search?searchQuery=${searchQuery}`, "/profile_search")
+    }
+  }
+
+  return (
+    // <form>
     <TextField
+      onKeyDown={handleKeyPress}
       id="search-bar"
       className="text"
       onInput={(e) => {
@@ -41,15 +54,16 @@ const Bar = ({ setSearchQuery }) => (
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">
-            <IconButton type="submit" aria-label="search">
+            <IconButton type="submit" aria-label="search" onClick={() => router.push(`/profile_search?searchQuery=${searchQuery}`, "/profile_search")}>
               <SearchIcon style={{ fill: "gray" }} />
             </IconButton>
           </InputAdornment>
         ),
       }}
     />
-  </form>
-);
+    // </form>
+  );
+}
 const SearchBar = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const dataFiltered = filterData(searchQuery, data);

--- a/pages/forum.tsx
+++ b/pages/forum.tsx
@@ -31,6 +31,7 @@ type PostProps = {
   account: VolunteerAccount;
   username: string;
   email: string;
+  allAccounts: VolunteerAccount[];
 };
 
 const Forum: NextPage<PostProps> = ({
@@ -41,6 +42,7 @@ const Forum: NextPage<PostProps> = ({
   email,
   chatInfo,
   account,
+  allAccounts
 }) => {
   const [active, setActive] = useState("friends");
 
@@ -95,7 +97,7 @@ const Forum: NextPage<PostProps> = ({
             </h1>
           </Grid2>
           <Grid2 sx={{ justifyContent: "left" }}>
-            <SearchBar />
+            <SearchBar allAccounts={allAccounts}/>
           </Grid2>
           <Grid2 container flexDirection="row" spacing={4}>
             <Grid2 sx={{ width: "50vw" }}>
@@ -284,6 +286,7 @@ export const getServerSideProps = async (context: any) => {
     const account: VolunteerAccount = (await VolunteerAccount.findOne({
       email: session.user?.email,
     })) as VolunteerAccount;
+    const allAccounts = await VolunteerAccount.find({}) as VolunteerAccount[]
     //const name = account.fname + " " + account.lname;
     //console.log("account", account);
     // console.log("account email", account.email);
@@ -324,6 +327,7 @@ export const getServerSideProps = async (context: any) => {
         myPosts: JSON.parse(JSON.stringify(myPosts)),
         chatInfo: JSON.parse(JSON.stringify(chatInfo)),
         account: JSON.parse(JSON.stringify(account)),
+        allAccounts: JSON.parse(JSON.stringify(allAccounts)),
         username: userName,
         email: volunteerEmail,
         user: JSON.parse(JSON.stringify(account)),

--- a/pages/profile_search.tsx
+++ b/pages/profile_search.tsx
@@ -30,20 +30,21 @@ type ProfileProps = {
   drives: BookDrive[] | null;
   broadcasts: Broadcast[];
   allAccounts: VolunteerAccount[];
+  query: string | null // represents the query parameter if the profile search page is reached from the forum page
 };
-const profile_search: NextPage<ProfileProps> = ({broadcasts, account, drives, error, allAccounts }) => {
+const profile_search: NextPage<ProfileProps> = ({ broadcasts, account, drives, error, allAccounts, query }) => {
   //console.log("Profile Page");
-
+  console.log("query", query)
   const handleFriendRequest = () => {
     // Handle the logic for sending a friend request
     console.log('Friend request sent');
   };
- const backButtonStyle: React.CSSProperties = {
+  const backButtonStyle: React.CSSProperties = {
     color: '#FE9834',
     cursor: 'pointer',
     marginTop: '50px',
     marginLeft: '100px',
-    marginBottom: '-50px', 
+    marginBottom: '-50px',
     textDecoration: 'none', // Remove default link underline
     display: 'flex',
     alignItems: 'center', // Center items vertically
@@ -61,7 +62,7 @@ const profile_search: NextPage<ProfileProps> = ({broadcasts, account, drives, er
   const states = getStates();
   const allProfiles = allAccounts.map((account) => ({
     name: `${account.fname} ${account.lname}`,
-    state: states[account.location-1].name,
+    state: states[account.location - 1].name,
     email: `${account.email}`,
     profilePicture:
       "https://kellercenter.princeton.edu/sites/default/files/styles/square/public/images/2020%20Incubator%20-%2010X%20Project%20-%20Ivy%20Wang.JPG?h=3ba71f74&itok=0YopKwug",
@@ -80,95 +81,47 @@ const profile_search: NextPage<ProfileProps> = ({broadcasts, account, drives, er
       },
     ],
   }));
-  
-  if (account) {
-    console.log("ACCOUNT: ", account);
-    const [filteredUsers, setFilteredUsers] = useState<VolunteerAccount[]>([]);
-    const [filteredProfiles, setFilteredProfiles] = useState<
-      Array<{
-        name: string;
-        state: string;
-        email: string;
-        profilePicture: string;
-        badges: Array<{
-          isEarned: boolean;
-          level: number;
-          name: string;
-          description: string;
-        }>;
-      }>
-    >([]);
-    const users: VolunteerAccount[] = [ /* Add your user data here */ ];
-
-    const handleQueryChange = (query: string, filteredUsers: VolunteerAccount[]) => {
-      /*if (query.trim() === '') {
-        setFilteredProfiles([]); // If the query is empty, set filteredProfiles to an empty array
-      } else {*/
-      const filteredProfiles = allProfiles.filter((profile) =>
-        profile.name.toLowerCase().includes(query.toLowerCase())
-      );
-
-      setFilteredProfiles(filteredProfiles);
-      //}
-      
-    };
-    //console.log(allAccounts)
-    console.log(filteredProfiles)
-
-    
-    const numbers = Array.from({ length: 9 }, (_, i) => i + 1); // Generate an array of numbers from 1 to 9
-
-
-    return (
-      <Grid>
-        <PageContainer
-          broadcasts={broadcasts}
-          fName={account.fname}
-          currPage="profile_search"
-        />
-        <Grid
-          container
-          display="flex"
-          padding={2}
-          sx={{ pl: 20 }}
-          rowSpacing={3}
-        >
-          <Grid item xs={12} sm={7} display="flex" flexDirection="column">
-            <SearchBar
-              users={users}
-              onQueryChange={handleQueryChange}
-              onBackToForum={() => {}}
-            />
-          </Grid>
-          <Grid item xs={12} sm={7} display="flex" flexDirection="column">
-            <Link href="/forum">
-              <a style={backButtonStyle}>
-                <span style={backIconStyle}>&lt;</span> Back to Forum
-              </a>
-            </Link>
-          </Grid>
-          <Grid
-          container
-          display="flex"
-          padding={1}
-          sx={{ pl:5 }}
-          spacing={3}
-        >
-          <Grid
-            item
-            xs={12}
-            sm={5}
-            mt={6}
-            sx={{  margin: "25 0px" }}
-          >
-            <ProfileDisplayCase profiles={filteredProfiles} useBadges={true} />
-          </Grid>
-        </Grid>
-        </Grid>
-
-      </Grid>
+  const handleQueryChange = (query: string, filteredUsers: VolunteerAccount[]) => {
+    /*if (query.trim() === '') {
+      setFilteredProfiles([]); // If the query is empty, set filteredProfiles to an empty array
+    } else {*/
+    const filteredProfiles = allProfiles.filter((profile) =>
+      profile.name.toLowerCase().includes(query.toLowerCase())
     );
-  } else {
+
+    setFilteredProfiles(filteredProfiles);
+    //}
+
+  };
+
+
+  const [filteredUsers, setFilteredUsers] = useState<VolunteerAccount[]>([]);
+  const [filteredProfiles, setFilteredProfiles] = useState<
+    Array<{
+      name: string;
+      state: string;
+      email: string;
+      profilePicture: string;
+      badges: Array<{
+        isEarned: boolean;
+        level: number;
+        name: string;
+        description: string;
+      }>;
+    }>
+  >([]);
+  const users: VolunteerAccount[] = [ /* Add your user data here */];
+  // if there was a query url param (coming from forum) then it should autosearch
+  useEffect(() => {
+    if (query) handleQueryChange(query, [])
+  }, [])
+  //console.log(allAccounts)
+  console.log(filteredProfiles)
+
+
+  const numbers = Array.from({ length: 9 }, (_, i) => i + 1); // Generate an array of numbers from 1 to 9
+  if (!account) {
+
     return (
       <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "100px", flexDirection: "column" }}>
         <h1>{error}</h1>
@@ -180,6 +133,58 @@ const profile_search: NextPage<ProfileProps> = ({broadcasts, account, drives, er
       </div>
     );
   }
+
+
+  return (
+    <Grid>
+      <PageContainer
+        broadcasts={broadcasts}
+        fName={account.fname}
+        currPage="profile_search"
+      />
+      <Grid
+        container
+        display="flex"
+        padding={2}
+        sx={{ pl: 20 }}
+        rowSpacing={3}
+      >
+        <Grid item xs={12} sm={7} display="flex" flexDirection="column">
+          <SearchBar
+            users={users}
+            onQueryChange={handleQueryChange}
+          onBackToForum={() => { }}
+          />
+        </Grid>
+        <Grid item xs={12} sm={7} display="flex" flexDirection="column" sx={{ cursor: "pointer" }}>
+          <Link href="/forum">
+            <a style={backButtonStyle}>
+              <span style={backIconStyle}>&lt;</span> Back to Forum
+            </a>
+          </Link>
+        </Grid>
+        <Grid
+          container
+          display="flex"
+          padding={1}
+          sx={{ pl: 5 }}
+          spacing={3}
+        >
+          <Grid
+            item
+            xs={12}
+            sm={5}
+            mt={6}
+            sx={{ margin: "25 0px" }}
+          >
+            <ProfileDisplayCase profiles={filteredProfiles} useBadges={true} />
+          </Grid>
+        </Grid>
+      </Grid>
+
+    </Grid>
+  );
+
 };
 export const getServerSideProps = async (context: any) => {
   try {
@@ -195,12 +200,14 @@ export const getServerSideProps = async (context: any) => {
       }
     }
     const email = session.user.email
-    
+
+    const query = context.query.searchQuery
+
     await dbConnect()
     const VolunteerAccount: mongoose.Model<VolunteerAccount> = getVolunteerAccountModel()
     const BookDrive: mongoose.Model<BookDrive> = getBookDriveModel()
     const volunteerAccount: VolunteerAccount | null = await VolunteerAccount.findOne({ email: email });
-    if(!volunteerAccount) throw new Error("Volunteer account not found")
+    if (!volunteerAccount) throw new Error("Volunteer account not found")
     // findsall completed bookDrives that correspond to the volunteer account
     const promises = volunteerAccount!.driveIds.map(async (driveId: string) => await BookDrive.find({ driveCode: driveId, status: BookDriveStatus.Completed }));
     // you have to resolve these promises before continuing
@@ -210,7 +217,7 @@ export const getServerSideProps = async (context: any) => {
     const Broadcast: mongoose.Model<Broadcast> = getBroadcastModel();
 
     const allAccounts = (await VolunteerAccount.find({})) as VolunteerAccount[];
-    
+
     console.log(volunteerAccount.broadcasts);
     const bPromises = volunteerAccount.broadcasts.map((broadcastId) => {
       const res = Broadcast.findOne({ id: broadcastId });
@@ -227,6 +234,7 @@ export const getServerSideProps = async (context: any) => {
         drives: JSON.parse(JSON.stringify(drives)) as BookDrive,
         allAccounts: JSON.parse(JSON.stringify(allAccounts)),
         error: null,
+        query: query ? query : null
       },
     };
   } catch (e: Error | any) {
@@ -234,7 +242,7 @@ export const getServerSideProps = async (context: any) => {
     // if the specific error message occurs it's because the user has not logged in
     let strError = e.message === "Cannot read properties of null (reading 'user')" ? "You must login before accessing this page" : `${e}`
 
-    return { props: { error: strError, account: null, drives: null } }
+    return { props: { error: strError, account: null, drives: null, query: null } }
   }
 
 }


### PR DESCRIPTION
Adde the preliminary search results under the search bar in the forum page (pfp and name). When you hit enter on a search query, it takes you to the profile_search page and automatically runs the search with the query that was input in the forum page. Clicking on a preliminary search result does nothing for now. 

Generally looking for aesthetic feedback and functional feedback in terms of what else (if anything) should be included in the preliminary search result for a profile and what should happen when you click on a preliminary search result.

To recreate:

log in as test3@test.com
go to the forum page and start typing in the search bar. You should see that some results appear and then disappear based on the query.
if you type in test and then scroll down the list, the currently highlighted item should appear light gray instead of white.
if you have a query entered and there are preliminary results, click outside of the search results and the search results should go away.
if you type in a query (like test) and hit enter, it should take you to the profile_search page with a query of test already entered.
Resizing while there are search results should maintain the position of the search results relative to the search bar.