### PR TITLE
290 m edit profile

### DIFF
--- a/components/CircularIcon.tsx
+++ b/components/CircularIcon.tsx
@@ -1,7 +1,7 @@
 
-const CircularIcon: React.FC<{ stringContent?: string | null, reactNodeContent?: React.ReactNode | null, bgColor: string, fgColor?: string, diameter?: string, onClick?: () => void }> = ({ stringContent, reactNodeContent, bgColor, fgColor, diameter, onClick }) => {
+const CircularIcon: React.FC<{ stringContent?: string | null, reactNodeContent?: React.ReactNode | null, bgColor: string, fgColor?: string, diameter?: string, viewBox?: string, onClick?: () => void }> = ({ stringContent, reactNodeContent, bgColor, fgColor, diameter, viewBox, onClick }) => {
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" onClick={onClick} width={diameter ? diameter : "28"} height={diameter ? diameter : "28"} viewBox="0 0 28 28" fill="none">
+        <svg xmlns="http://www.w3.org/2000/svg" onClick={onClick} width={diameter ? diameter : "28"} height={diameter ? diameter : "28"} viewBox={viewBox ? viewBox : "0 0 28 28"} fill="none">
             <circle cx="14" cy="14" r="14" fill={bgColor} />
             {reactNodeContent && reactNodeContent}
             {stringContent &&

--- a/components/Dropdown.tsx
+++ b/components/Dropdown.tsx
@@ -1,0 +1,49 @@
+import React, { useState, Dispatch, SetStateAction, useRef } from 'react';
+import useClickOutside from '../lib/useClickOutside';
+
+interface DropdownProps {
+    options: { name: string, index: number }[];
+    setResult: Dispatch<SetStateAction<number>>;
+    location: number
+}
+
+const Dropdown: React.FC<DropdownProps> = ({ options, location, setResult }) => {
+    const [selectedOption, setSelectedOption] = useState<string | null>(options[location - 1].name);
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    const [hovered, setHovered] = useState(Array(options.length).fill(false))
+    const dropdownRef = useRef(null)
+    useClickOutside(dropdownRef, () => setIsDropdownOpen(false))
+    const handleOptionClick = (name: string, index: number) => {
+        setResult(index)
+        setSelectedOption(name)
+        setIsDropdownOpen(false);
+    };
+    const modifyHovered = (index: number, value: boolean) => {
+        const newHovered = Array(options.length).fill(false)
+        newHovered[index] = value
+        setHovered(newHovered)
+    }
+
+    const toggleDropdown = () => {
+        setIsDropdownOpen(!isDropdownOpen);
+    };
+
+    return (
+        <div style={{ position: "relative", zIndex: 1, width: "90%" }}>
+            <div onClick={toggleDropdown} style={{ cursor: 'pointer', border: '1px solid #ccc', padding: 5, borderRadius: '4px', zIndex: 2, backgroundColor: "white" }}>
+                {selectedOption || 'Select an option'}
+            </div>
+            {isDropdownOpen && (
+                <div ref={dropdownRef} style={{ border: '1px solid #ccc', marginTop: '4px', borderRadius: '4px', position: 'absolute', top: "100%", left: "0", zIndex: 3, maxHeight: "150px", overflowY: "auto", width: "100%", backgroundColor: "white" }}>
+                    {options.map((option, i) => (
+                        <div key={option.index} onMouseEnter={() => modifyHovered(i, true)} onMouseLeave={() => modifyHovered(i, false)} onClick={() => handleOptionClick(option.name, option.index)} style={{ padding: '8px', cursor: 'pointer', backgroundColor: hovered[i] ? "#F5F5F5" : "white" }}>
+                            {option.name}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default Dropdown

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -193,10 +193,6 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
   }, [snackbarOpen]);
 
 
-  const showEditProfileModal = () => {
-
-  }
-
   return (
     <>
       <Grid>
@@ -311,14 +307,14 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
         <div style={{ display: "flex", alignItems: "center" }}>
 
           <h1 style={{ textAlign: "left", fontSize: fontsize, paddingRight: 10, color: "#5F5F5f" }}>{pageName}</h1>
-          {pageName === 'Profile' && <div style={{ position: "relative" }}>
+          {/* {pageName === 'Profile' && <div style={{ position: "relative" }}>
             <svg xmlns="http://www.w3.org/2000/svg" width="71" height="71" viewBox="0 0 71 71" fill="none">
               <circle cx="35.5" cy="35.5" r="35.5" fill="#5F5F5F" />
             </svg>
             <svg xmlns="http://www.w3.org/2000/svg" width="39" height="39" viewBox="0 0 39 39" fill="none" style={{ position: "absolute", top: 13, left: 15 }}>
               <path d="M39 10.2173C39.0014 9.96066 38.9523 9.70627 38.8552 9.46871C38.7582 9.23114 38.6152 9.01507 38.4345 8.83287L30.1665 0.56549C29.9843 0.384775 29.7682 0.241802 29.5306 0.144768C29.293 0.0477341 29.0386 -0.00145104 28.782 3.25904e-05C28.5254 -0.00145104 28.271 0.0477341 28.0334 0.144768C27.7958 0.241802 27.5797 0.384775 27.3975 0.56549L21.879 6.08358L0.565532 27.3955C0.384803 27.5777 0.241819 27.7938 0.144778 28.0313C0.0477376 28.2689 -0.00145115 28.5233 3.25928e-05 28.7799V37.0473C3.25928e-05 37.5644 0.205478 38.0604 0.571173 38.426C0.936869 38.7917 1.43286 38.9971 1.95003 38.9971H10.218C10.4909 39.012 10.7638 38.9693 11.0191 38.8719C11.2744 38.7745 11.5064 38.6245 11.7 38.4317L32.8965 17.1198L38.4345 11.6992C38.6125 11.5102 38.7575 11.2927 38.8635 11.0557C38.8823 10.9003 38.8823 10.7432 38.8635 10.5877C38.8726 10.497 38.8726 10.4055 38.8635 10.3148L39 10.2173ZM9.41852 35.0974H3.90003V29.5793L23.2635 10.2173L28.782 15.7354L9.41852 35.0974ZM31.5315 12.9861L26.013 7.46797L28.782 4.71868L34.281 10.2173L31.5315 12.9861Z" fill="white" />
             </svg>
-          </div>}
+          </div>} */}
         </div>
       </Grid>
       <Snackbar

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,4 +1,4 @@
-import { Box, Drawer, Link, List, ListItem, ListItemButton, ListItemIcon,  Collapse } from '@mui/material';
+import { Box, Drawer, Link, List, ListItem, ListItemButton, ListItemIcon, Collapse } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Button, { ButtonProps } from '@mui/material/Button';
 import Grid from '@mui/material/Unstable_Grid2'; // Grid version 2
@@ -7,18 +7,18 @@ import Navbar from '../components/Navbar'
 import { signOut } from "next-auth/react"
 import useDynamicPadding from '../lib/useDynamicPadding';
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import { Popover, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { Broadcast } from "../models/Broadcast";
 import FriendRequestCard from '../components/FriendRequestCard';
-import FriendRequest from '../components/FriendRequest'; 
+import FriendRequest from '../components/FriendRequest';
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import { Switch } from '@mui/material';
 import { VolunteerAccount } from "../models/VolunteerAccount";
 import { getStates } from "../lib/enums";
-
+import CircularIcon from './CircularIcon';
 
 interface FriendInfo {
   email: string;
@@ -31,12 +31,12 @@ interface FriendInfo {
 }
 
 type PageContainerProps = {
-    fName: String;
-    userEmail?: string;
-    currPage: "dash-volunteer" | "profile" | "instruction-steps" | "h4i-team" | "forum" | "leaderboard" | "profile_search";
-    broadcasts ?: Broadcast[];
-    friendRequests?: string[];
-    allVolunteers?: VolunteerAccount[];
+  fName: String;
+  userEmail?: string;
+  currPage: "dash-volunteer" | "profile" | "instruction-steps" | "h4i-team" | "forum" | "leaderboard" | "profile_search";
+  broadcasts?: Broadcast[];
+  friendRequests?: string[];
+  allVolunteers?: VolunteerAccount[];
 }
 
 
@@ -61,15 +61,15 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
   // friend request stuff
   const reqEmailSet = new Set(friendRequests);
   const states = getStates();
-  let friendInfo:FriendInfo[] = []
+  let friendInfo: FriendInfo[] = []
   const myEmail = userEmail || "";
   const [friendInfoList, setFriendInfoList] =
-      useState<FriendInfo[]>([]);
-  if (allVolunteers){
+    useState<FriendInfo[]>([]);
+  if (allVolunteers) {
     friendInfo = allVolunteers
-    .map((account) =>
-      reqEmailSet.has(account.email)
-        ? {
+      .map((account) =>
+        reqEmailSet.has(account.email)
+          ? {
             email: account.email,
             fname: account.fname,
             lname: account.lname[0],
@@ -77,9 +77,9 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
             pfp: account.pfpLink,
             // Add or modify properties as needed
           }
-        : null
-    )
-    .filter((item) => item !== null) as FriendInfo[];
+          : null
+      )
+      .filter((item) => item !== null) as FriendInfo[];
   }
 
   /*const updateFriendReqs = (friendReqEmail: string) => {
@@ -98,11 +98,11 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
     setActiveFilter(filter);
   };
 
-    const handleClosePopover = () => {
-        setPopoverOpen(false);
-    };
+  const handleClosePopover = () => {
+    setPopoverOpen(false);
+  };
 
-    const handleBroadcastClick = (index: number) => {
+  const handleBroadcastClick = (index: number) => {
     // Toggle the visibility of the clicked broadcast message
     const updatedVisibility = [...visibleBroadcasts];
     updatedVisibility[index] = !updatedVisibility[index];
@@ -129,61 +129,61 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
     setSnackbarOpen(true);
   };
 
-    const handleActionCompleted = (message: string) => {
+  const handleActionCompleted = (message: string) => {
     setSnackbarMessage(message);
     setSnackbarOpen(true);
   };
 
 
-    let pageName = "";
-    let fontsize = "";
-    switch (currPage) {
-        case "dash-volunteer": {
-            pageName = "Home";
-            fontsize = "90px";
-            break;
-        }
-        case "profile": {
-            pageName = "Profile";
-            fontsize = "90px";
-            break;
-        }
-        case "instruction-steps": {
-            pageName = "Organizer Steps";
-            fontsize = "70px";
-            break;
-        }
-        case "h4i-team": {
-            pageName = "The Developer Team";
-            fontsize = "90px";
-            break;
-        }
-        case "forum": {
-            pageName = "Forum";
-            fontsize = "90px";
-            break;
-        }
-        case "leaderboard": {
-            pageName = "Leaderboard";
-            fontsize = "90px";
-            break;
-        }
-        case "profile_search": {
-            pageName = "Profile Search";
-            fontsize = "90px";
-            break;
-        }
+  let pageName = "";
+  let fontsize = "";
+  switch (currPage) {
+    case "dash-volunteer": {
+      pageName = "Home";
+      fontsize = "90px";
+      break;
     }
+    case "profile": {
+      pageName = "Profile";
+      fontsize = "90px";
+      break;
+    }
+    case "instruction-steps": {
+      pageName = "Organizer Steps";
+      fontsize = "70px";
+      break;
+    }
+    case "h4i-team": {
+      pageName = "The Developer Team";
+      fontsize = "90px";
+      break;
+    }
+    case "forum": {
+      pageName = "Forum";
+      fontsize = "90px";
+      break;
+    }
+    case "leaderboard": {
+      pageName = "Leaderboard";
+      fontsize = "90px";
+      break;
+    }
+    case "profile_search": {
+      pageName = "Profile Search";
+      fontsize = "90px";
+      break;
+    }
+  }
 
-    const handleSignOut = () => {
-        console.log("Signing out user");
-        signOut();
-        window.location.href = '/';
-    }
-    useEffect(()=> {      
-      setFriendInfoList(friendInfo);
-    }, [])
-    useEffect(() => {
+  const handleSignOut = () => {
+    console.log("Signing out user");
+    signOut();
+    window.location.href = '/';
+  }
+  useEffect(() => {
+    setFriendInfoList(friendInfo);
+  }, [])
+  useEffect(() => {
     if (snackbarOpen) {
       const timeoutId = setTimeout(() => {
         setSnackbarOpen(false);
@@ -193,8 +193,11 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
   }, [snackbarOpen]);
 
 
+  const showEditProfileModal = () => {
 
-   return (
+  }
+
+  return (
     <>
       <Grid>
         <Navbar active={currPage}></Navbar>
@@ -214,85 +217,85 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
               <InboxIconButton color="inherit" onClick={handleOpenPopover}>
                 <InboxIcon></InboxIcon>
               </InboxIconButton>
-                <Popover
+              <Popover
                 open={popoverOpen}
                 anchorEl={anchorEl}
                 onClose={handleClosePopover}
                 anchorOrigin={{
-                    vertical: 66.5,
-                    horizontal: 'right',
+                  vertical: 66.5,
+                  horizontal: 'right',
                 }}
                 sx={{ backgroundColor: 'rgba(0, 0, 0, 0.1)' }}
-                >
+              >
                 <Box p={2}>
-                    <Typography variant="h6" sx={{ color: '#fe9834' }}>Inbox</Typography>
-                    {/* Add buttons to filter friend requests and broadcasts */}
-                    <Button
+                  <Typography variant="h6" sx={{ color: '#fe9834' }}>Inbox</Typography>
+                  {/* Add buttons to filter friend requests and broadcasts */}
+                  <Button
                     variant="contained"
                     disableElevation
                     sx={{
-                        borderRadius: 0,
-                        backgroundColor: activeFilter === "all" ? "#F3D39A" : "#F5F5F5",
-                        color: "#5F5F5F",
-                        mx: 0.5, // Margin on the left and right
-                        my: 1, // Margin on the top and bottom
-                        fontWeight: activeFilter === "all" ? "bold" : "normal", // Bold when active
+                      borderRadius: 0,
+                      backgroundColor: activeFilter === "all" ? "#F3D39A" : "#F5F5F5",
+                      color: "#5F5F5F",
+                      mx: 0.5, // Margin on the left and right
+                      my: 1, // Margin on the top and bottom
+                      fontWeight: activeFilter === "all" ? "bold" : "normal", // Bold when active
                     }}
                     onClick={() => handleFilterClick("all")}
-                    >
+                  >
                     Broadcasts
-                    </Button>
-                    <Button
+                  </Button>
+                  <Button
                     variant="contained"
                     disableElevation
                     sx={{
-                        borderRadius: 0,
-                        backgroundColor: activeFilter === "friends" ? "#F3D39A" : "#F5F5F5",
-                        color: "#5F5F5F",
-                        mx: 0.5, // Margin on the left and right
-                        my: 1, // Margin on the top and bottom
-                        fontWeight: activeFilter === "friends" ? "bold" : "normal", // Bold when active
+                      borderRadius: 0,
+                      backgroundColor: activeFilter === "friends" ? "#F3D39A" : "#F5F5F5",
+                      color: "#5F5F5F",
+                      mx: 0.5, // Margin on the left and right
+                      my: 1, // Margin on the top and bottom
+                      fontWeight: activeFilter === "friends" ? "bold" : "normal", // Bold when active
                     }}
                     onClick={() => handleFilterClick("friends")}
-                    >
+                  >
                     Friend Requests
-                    </Button>
-                    {/* Add more filters as needed */}
-                    {activeFilter === "all" && broadcasts?.map((broadcast, index) => (
+                  </Button>
+                  {/* Add more filters as needed */}
+                  {activeFilter === "all" && broadcasts?.map((broadcast, index) => (
                     <Collapse in={visibleBroadcasts[index]} key={index} sx={{ transition: '0.3s' }}>
-                        <Box sx={{
+                      <Box sx={{
                         width: '300px',
                         borderRadius: '10px',
                         boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.2)',
                         border: '1px solid #d89600',
                         padding: '12px',
                         mb: 2, // Add margin-bottom for space
-                        }}>
+                      }}>
                         <Typography variant="body1" sx={{ cursor: 'pointer', flex: 1 }} onClick={() => handleBroadcastClick(index)}>
-                            {broadcast.message}
+                          {broadcast.message}
                         </Typography>
-                        </Box>
+                      </Box>
                     </Collapse>
+                  ))}
+                  {activeFilter === 'friends' &&
+                    friendInfoList.map((request, index) => (
+                      <div key={index} style={{ marginBottom: '10px' }}>
+                        <FriendRequestCard
+                          key={index}
+                          profilePicture={request.pfp}
+                          name={request.fname}
+                          reqEmail={request.email}
+                          state={request.state.name}
+                          myEmail={myEmail}
+                          requeststate='pending'
+                          onApprove={() => handleApproveFriendRequest(request.email)}
+                          onReject={() => handleRejectFriendRequest(request.email)}
+                          onActionCompleted={handleActionCompleted}
+                        />
+                      </div>
                     ))}
-                        {activeFilter === 'friends' &&
-                            friendInfoList.map((request, index) => (
-                            <div key={index} style={{ marginBottom: '10px' }}>
-                                <FriendRequestCard
-                                key={index}
-                                profilePicture={request.pfp}
-                                name={request.fname}
-                                reqEmail={request.email}
-                                state={request.state.name}
-                                myEmail={myEmail}
-                                requeststate='pending'
-                                onApprove={() => handleApproveFriendRequest(request.email)}
-                                onReject={() => handleRejectFriendRequest(request.email)}
-                                onActionCompleted={handleActionCompleted}
-                                />
-                            </div>
-                            ))}
                 </Box>
-                </Popover>
+              </Popover>
             </Grid>
             <Grid xs={3}><WhiteTextButton variant="text" className="signout" onClick={handleSignOut}> Sign Out </WhiteTextButton></Grid>
             <Grid xs={2}><img src="/alp-logo.png" alt="alp-logo" height="55px"></img></Grid>
@@ -305,7 +308,18 @@ const PageContainer: React.FC<PageContainerProps> = ({ fName, userEmail, currPag
         <Box sx={{
           height: '12vh',
         }}></Box>
-        <h1 style={{ textAlign: "left", fontSize: fontsize, paddingRight: 10 }}>{pageName}</h1>
+        <div style={{ display: "flex", alignItems: "center" }}>
+
+          <h1 style={{ textAlign: "left", fontSize: fontsize, paddingRight: 10, color: "#5F5F5f" }}>{pageName}</h1>
+          {pageName === 'Profile' && <div style={{ position: "relative" }}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="71" height="71" viewBox="0 0 71 71" fill="none">
+              <circle cx="35.5" cy="35.5" r="35.5" fill="#5F5F5F" />
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="39" height="39" viewBox="0 0 39 39" fill="none" style={{ position: "absolute", top: 13, left: 15 }}>
+              <path d="M39 10.2173C39.0014 9.96066 38.9523 9.70627 38.8552 9.46871C38.7582 9.23114 38.6152 9.01507 38.4345 8.83287L30.1665 0.56549C29.9843 0.384775 29.7682 0.241802 29.5306 0.144768C29.293 0.0477341 29.0386 -0.00145104 28.782 3.25904e-05C28.5254 -0.00145104 28.271 0.0477341 28.0334 0.144768C27.7958 0.241802 27.5797 0.384775 27.3975 0.56549L21.879 6.08358L0.565532 27.3955C0.384803 27.5777 0.241819 27.7938 0.144778 28.0313C0.0477376 28.2689 -0.00145115 28.5233 3.25928e-05 28.7799V37.0473C3.25928e-05 37.5644 0.205478 38.0604 0.571173 38.426C0.936869 38.7917 1.43286 38.9971 1.95003 38.9971H10.218C10.4909 39.012 10.7638 38.9693 11.0191 38.8719C11.2744 38.7745 11.5064 38.6245 11.7 38.4317L32.8965 17.1198L38.4345 11.6992C38.6125 11.5102 38.7575 11.2927 38.8635 11.0557C38.8823 10.9003 38.8823 10.7432 38.8635 10.5877C38.8726 10.497 38.8726 10.4055 38.8635 10.3148L39 10.2173ZM9.41852 35.0974H3.90003V29.5793L23.2635 10.2173L28.782 15.7354L9.41852 35.0974ZM31.5315 12.9861L26.013 7.46797L28.782 4.71868L34.281 10.2173L31.5315 12.9861Z" fill="white" />
+            </svg>
+          </div>}
+        </div>
       </Grid>
       <Snackbar
         open={snackbarOpen}

--- a/pages/volunteeraccounts/profile.tsx
+++ b/pages/volunteeraccounts/profile.tsx
@@ -3,7 +3,7 @@ import dbConnect from '../../lib/dbConnect';
 import { Grid, IconButton, Button, TextField, FormControl, InputLabel, Select, OutlinedInput, MenuItem, SelectChangeEvent } from "@mui/material";
 import Box from '@mui/material/Box';
 import PageContainer from "../../components/PageContainer";
-import React, { useState, useRef, Dispatch, SetStateAction } from 'react';
+import React, { useState, useRef, Dispatch, SetStateAction, useEffect } from 'react';
 import { signOut } from "next-auth/react";
 import MapComponent from '../../components/MapComponent';
 import Link from 'next/link';
@@ -169,12 +169,17 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
   const [pfpURL, setpfpURL] = useState<string>((account) ? account.pfpLink : "https://icons.iconarchive.com/icons/pictogrammers/material/512/account-circle-icon.png")
   const states = getStates()
   const [currAccount, setCurrAccount] = useState(account)
-
-  console.log("Profile Page");
+  useEffect(() => {
+    console.log(currAccount)
+  }, [currAccount])
   // if the account is not null, that means that everything is working
   // otherwise render the error message page
   const toggleShowEditProfileModal = (val: boolean) => {
-    if (val) editProfileRef?.current?.showModal()
+    if (val) {
+      setName(`${currAccount!.fname} ${currAccount!.lname}`)
+      setLocation(currAccount!.location)
+      editProfileRef?.current?.showModal()
+    }
     else {
       editProfileRef?.current?.close()
       setName(`${currAccount!.fname} ${currAccount!.lname}`)

--- a/pages/volunteeraccounts/profile.tsx
+++ b/pages/volunteeraccounts/profile.tsx
@@ -1,13 +1,13 @@
 import getVolunteerAccountModel, { VolunteerAccount } from "../../models/VolunteerAccount";
 import dbConnect from '../../lib/dbConnect';
-import { Grid, IconButton } from "@mui/material";
+import { Grid, IconButton, Button, TextField, FormControl, InputLabel, Select, OutlinedInput, MenuItem, SelectChangeEvent } from "@mui/material";
 import Box from '@mui/material/Box';
 import PageContainer from "../../components/PageContainer";
-import { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { signOut } from "next-auth/react";
 import MapComponent from '../../components/MapComponent';
 import Link from 'next/link';
-import { BookDriveStatus } from "../../lib/enums";
+import { BookDriveStatus, getStates } from "../../lib/enums";
 import getBookDriveModel, { BookDrive } from "../../models/BookDrive";
 import { NextPage } from 'next';
 import mongoose from 'mongoose';
@@ -16,7 +16,7 @@ import { authOptions } from "../api/auth/[...nextauth]";
 import getBroadcastModel, { Broadcast } from "../../models/Broadcast";
 import { PhotoCamera } from "@mui/icons-material";
 import { imageDelete, imagePfpUpload } from "../../db_functions/imageDB";
-
+import CircularIcon from "../../components/CircularIcon";
 type ProfileProps = {
   error: string | null;
   account: VolunteerAccount | null;
@@ -123,7 +123,7 @@ const BookDrivesCompletedGraph = () => {
 
 const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives }) => {
   const [pfpURL, setpfpURL] = useState<string>((account) ? account.pfpLink : "https://icons.iconarchive.com/icons/pictogrammers/material/512/account-circle-icon.png")
-
+  const states = getStates()
   const changeHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files) return
     const file = event.target.files[0]
@@ -152,6 +152,18 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
   console.log("Profile Page");
   // if the account is not null, that means that everything is working
   // otherwise render the error message page
+  const toggleShowEditProfileModal = (val: boolean) => {
+    if (val) editProfileRef?.current?.showModal()
+    else editProfileRef?.current?.close()
+
+  }
+  const editProfileRef = useRef<HTMLDialogElement>(null)
+  const [name, setName] = useState(`${account!.fname} ${account!.lname}`)
+  const [location, setLocation] = useState(account!.location)
+  const [email, setEmail] = useState(account!.email)
+  const [affiliation, setAffiliation] = useState("")
+  const [favBook, setFavBook] = useState("")
+
   if (account) {
     return (
       <Grid>
@@ -221,10 +233,129 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
                 <p style={{ fontWeight: 800, fontSize: 30, marginBottom: 2, color: "#5F5F5F" }}>{`${account.fname} ${account.lname}`}</p>
                 <p style={{ fontWeight: 500, marginBottom: 2, color: "#5F5F5F" }}>{account.email}</p>
                 <p style={{ fontWeight: 500, color: "#5F5F5F" }}>{`# of Bookdrives completed: ${drives!.length}`}</p>
+                <p style={{ marginTop: 16, color: "blue", fontWeight: 600, cursor: "pointer" }} onClick={() => toggleShowEditProfileModal(true)}>Edit Profile</p>
               </div>
+
             </Box>
             <BookDrivesCompletedGraph />
             <BadgeDisplayCase />
+            <dialog
+              ref={editProfileRef}
+              style={{
+                height: "70%",
+                width: "50%",
+                borderRadius: "3%",
+                padding: 0,
+                position: "absolute",
+                left: "50%",
+                top: "50%",
+                transform: "translate(-50%, -50%)",
+              }}
+            >
+              <Grid
+                display={"flex"}
+                flexDirection={"column"}
+                justifyContent={"space-between"}
+                alignItems={"center"}
+                alignSelf={"flex-start"}
+                height={"100%"}
+                sx={{
+                  backgroundColor: "#F5F5F5",
+                  width: "100%",
+                  height: "100%",
+                }}
+              >
+                <Grid
+                  display="flex"
+                  flexDirection="row"
+                  alignItems="center"
+                  justifyContent={"space-between"}
+                  width="100%"
+                  sx={{ marginTop: 1 }}
+                >
+                  <p
+                    style={{
+                      color: "#5F5F5F",
+                      fontWeight: 600,
+                      fontSize: 20,
+                      width: "90%",
+                      marginLeft: "5%",
+                    }}
+                  >
+                    Edit Profile
+                  </p>
+                  <p style={{ cursor: "pointer", marginRight: 7, fontWeight: "600" }} onClick={() => toggleShowEditProfileModal(false)}>x</p>
+
+                </Grid>
+                <Grid flexDirection="row">
+                  <Grid flexDirection="column">
+                    <img src={pfpURL} />
+                    <Button>Upload new</Button>
+                    <Grid flexDirection={"column"} sx={{padding: 2}}>
+                      <input type="text" placeholder={"name"} style={{width: "85%"}} value={name} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}/>
+                      <FormControl sx={{ width: 300, border: "2px solid #5F5F5F", borderRadius: 2, backgroundColor: "#F5F5F5", zIndex: 1000 }}>
+                        <InputLabel id="state-label">State</InputLabel>
+                        <Select
+                          onChange={(e: SelectChangeEvent<string>) => setLocation(parseInt(e.target.value))}
+                          input={<OutlinedInput label="State" />}
+                        >
+                          {
+                            states.map((state) => (
+                              <MenuItem key={state.index} value={state.index} sx={{zIndex: 1000001}}>{state.name}</MenuItem>
+                            ))
+                          }
+                        </Select>
+                      </FormControl>
+                      <input type="text" placeholder={"email"} style={{width: "85%"}} value={email} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}/>
+                    </Grid>
+                  </Grid>
+
+                </Grid>
+                <TextField
+                  multiline
+                  autoFocus
+                  required
+                  placeholder="message"
+                  rows={7}
+                  sx={{
+                    width: "85%",
+                    marginBottom: "5px",
+                    backgroundColor: "#FFFFFF",
+                    color: "#FE9384",
+                    borderColor: "#FE9834",
+                  }}
+
+                />
+                <Grid
+                  display="flex"
+                  flexDirection="row"
+                  justifyContent="space-around"
+                  alignItems="center"
+                  sx={{ width: "50%" }}
+                >
+                  <Button
+                    sx={{
+                      backgroundColor: "#F3D39A",
+                      "&:hover": { backgroundColor: "#D3A874" },
+                      fontWeight: 550,
+                      color: "#5F5F5F",
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    sx={{
+                      backgroundColor: "#F3D39A",
+                      "&:hover": { backgroundColor: "#D3A874" },
+                      fontWeight: 550,
+                      color: "#5F5F5F",
+                    }}
+                  >
+                    Submit
+                  </Button>
+                </Grid>
+              </Grid>
+            </dialog>
           </Grid>
           <Grid item xs={12} sm={5} height={"418px"}>
             <Box


### PR DESCRIPTION
created edit profile modal with a few modifications compared to the figma

changes:
- the edit profile button couldn't go next to the title of the page 
- I made the profile picture upload button the same as it is on the normal page and changed the color to fit the scheme
- there is not yet support for hobbies, affiliation, and fav book because it doesn't exist in the database yet

to test:
1. log into test3
2. go to the profile page
3. click edit profile (inside of the first card)
4. modify the information, but don't click submit yet - click the "x" in the top right corner or click cancel. The newly input information shouldn't be saved, and should neither appear on the profile page nor appear on the profile page after reloading the page
5. modify the information and click submit - the changes should be reflected instantly.

let me know if I should add support for hobbies, affiliation, and fav book through modifications to the schema
