### PR TITLE
added personal info logic to the edit profile modal

### DIFF
--- a/components/Dropdown.tsx
+++ b/components/Dropdown.tsx
@@ -29,7 +29,7 @@ const Dropdown: React.FC<DropdownProps> = ({ options, location, setResult }) => 
     };
 
     return (
-        <div style={{ position: "relative", zIndex: 1, width: "90%" }}>
+        <div style={{ position: "relative", zIndex: 1, width: "93%" }}>
             <div onClick={toggleDropdown} style={{ cursor: 'pointer', border: '1px solid #ccc', padding: 5, borderRadius: '4px', zIndex: 2, backgroundColor: "white" }}>
                 {selectedOption || 'Select an option'}
             </div>

--- a/pages/volunteeraccounts/profile.tsx
+++ b/pages/volunteeraccounts/profile.tsx
@@ -233,12 +233,18 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
   const [favBook, setFavBook] = useState(currAccount.affiliation)
   const [hobbies, setHobbies] = useState(currAccount.hobbies)
   const editProfile = async () => {
+    const nameArr = name.trim().split(" ")
+    if (nameArr.length < 2) {
+      alert("Enter a valid first and last name")
+      return
+    }
+    setHobbies(hobbies.join(", ").trim().split(", "))
     const update = {
-      fname: name.split(" ")[0],
-      lname: name.split(" ")[1],
+      fname: nameArr[0],
+      lname: nameArr[nameArr.length-1],
       location: location,
-      affiliation: affiliation,
-      favoriteBook: favBook,
+      affiliation: affiliation.trim(),
+      favoriteBook: favBook.trim(),
       hobbies: hobbies,
     }
     const newAccount: VolunteerAccount = {

--- a/pages/volunteeraccounts/profile.tsx
+++ b/pages/volunteeraccounts/profile.tsx
@@ -106,41 +106,53 @@ const BadgeDisplayCase = () => {
   );
 };
 
-const PersonalInfoCard:React.FC< {account: VolunteerAccount} > = ({account}) => {
-  const affiliation = account.affiliation.length ? <p style={{display:"inline"}}>{account.affiliation}</p> : <p style={{display:"inline",fontStyle:"italic"}}>add your affiliation!</p>
-  const hobbies = account.hobbies.length ? <p style={{display:"inline"}}>{account.hobbies.join(', ')}</p>: <p style={{display:"inline",fontStyle:"italic"}}>add your hobbies!</p>
-  const faveBook = account.favoriteBook.length ?<p style={{display:"inline"}}>{account.favoriteBook}</p> : <p style={{display:"inline",fontStyle:"italic"}}>add your favorite book!</p>
-  
+const PersonalInfoCard: React.FC<{ account: VolunteerAccount }> = ({ account }) => {
+  const affiliation = account.affiliation.length ? <p style={{ display: "inline" }}>{account.affiliation}</p> : <p style={{ display: "inline", fontStyle: "italic" }}>add your affiliation!</p>
+  const hobbies = account.hobbies.length ? <p style={{ display: "inline" }}>{account.hobbies.join(', ')}</p> : <p style={{ display: "inline", fontStyle: "italic" }}>add your hobbies!</p>
+  const faveBook = account.favoriteBook.length ? <p style={{ display: "inline" }}>{account.favoriteBook}</p> : <p style={{ display: "inline", fontStyle: "italic" }}>add your favorite book!</p>
+
   return (
     <div style={{
       border: '1.5px solid black', padding: '10px', marginBottom: '10px', display: 'flex',
-      width: '95%', backgroundColor: "#F5F5F5",flexDirection:"column"
+      width: '95%', backgroundColor: "#F5F5F5", flexDirection: "column"
     }}>
       <h2 style={{ textAlign: 'left', marginBottom: '10px', paddingRight: '10px' }}>Personal Information</h2>
       <div>
         <Grid container alignItems={"center"}>
-            <div style={{paddingLeft:5,paddingRight:8}}>
-              <InfoIcon />
-            </div>
-            <span style={{ display: 'inline' }}><p style={{fontWeight:'bold', display:'inline'}}>Affiliation: </p>{affiliation}</span>
+          <div style={{ paddingLeft: 5, paddingRight: 8 }}>
+            <InfoIcon />
+          </div>
+          <span style={{ display: 'inline' }}><p style={{ fontWeight: 'bold', display: 'inline' }}>Affiliation: </p>{affiliation}</span>
         </Grid>
         <Grid container alignItems={"center"}>
-            <div style={{paddingLeft:5,paddingRight:8}}>
-              <SportsBasketballIcon />
-            </div>
-            <span style={{ display: 'inline' }}><p style={{fontWeight:'bold', display:'inline'}}>Hobbies: </p><p style={{display:'inline'}}>{hobbies}</p></span>
+          <div style={{ paddingLeft: 5, paddingRight: 8 }}>
+            <SportsBasketballIcon />
+          </div>
+          <span style={{ display: 'inline' }}><p style={{ fontWeight: 'bold', display: 'inline' }}>Hobbies: </p>{hobbies}</span>
         </Grid>
         <Grid container alignItems={"center"}>
-            <div style={{paddingLeft:5,paddingRight:8}}>
-              <AutoStoriesIcon />
-            </div>
-            <span style={{display:'inline'}}><p style={{fontWeight:'bold',display:'inline'}}>Favorite Book: </p><p style={{display:'inline'}}>{faveBook}</p></span>
+          <div style={{ paddingLeft: 5, paddingRight: 8 }}>
+            <AutoStoriesIcon />
+          </div>
+          <span style={{ display: 'inline' }}><p style={{ fontWeight: 'bold', display: 'inline' }}>Favorite Book: </p>{faveBook}</span>
         </Grid>
-        
       </div>
     </div>
   );
 };
+
+const ProfileError: React.FC<{ error: string }> = ({ error }) => {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "100px", flexDirection: "column" }}>
+      <h1>{error}</h1>
+      {// when the error is not an auth error give them the button to go back
+        error !== "You must login before accessing this page" &&
+        <Link href="/dash-volunteer">
+          <button style={{ width: "50px", height: "50px", borderRadius: "20%" }}>Volunteer Dashboard</button>
+        </Link>}
+    </div>
+  )
+}
 
 export const ImageUpload: React.FC<{ setpfpURL: Dispatch<SetStateAction<string>>, currAccount: VolunteerAccount }> = ({ setpfpURL, currAccount }) => {
   const changeHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -189,6 +201,7 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
   const [pfpURL, setpfpURL] = useState<string>((account) ? account.pfpLink : "https://icons.iconarchive.com/icons/pictogrammers/material/512/account-circle-icon.png")
   const states = getStates()
   const [currAccount, setCurrAccount] = useState(account)
+  if (!currAccount) return <ProfileError error={error!} />
   useEffect(() => {
     console.log(currAccount)
   }, [currAccount])
@@ -196,33 +209,43 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
   // otherwise render the error message page
   const toggleShowEditProfileModal = (val: boolean) => {
     if (val) {
-      setName(`${currAccount!.fname} ${currAccount!.lname}`)
-      setLocation(currAccount!.location)
+      setName(`${currAccount.fname} ${currAccount!.lname}`)
+      setLocation(currAccount.location)
+      setHobbies(currAccount.hobbies)
+      setAffiliation(currAccount.affiliation)
+      setFavBook(currAccount.favoriteBook)
       editProfileRef?.current?.showModal()
     }
     else {
       editProfileRef?.current?.close()
-      setName(`${currAccount!.fname} ${currAccount!.lname}`)
-      setLocation(currAccount!.location)
+      setName(`${currAccount.fname} ${currAccount.lname}`)
+      setLocation(currAccount.location)
+      setHobbies(currAccount.hobbies)
+      setAffiliation(currAccount.affiliation)
+      setFavBook(currAccount.favoriteBook)
     }
 
   }
   const editProfileRef = useRef<HTMLDialogElement>(null)
-  const [name, setName] = useState(`${currAccount!.fname} ${currAccount!.lname}`)
-  const [location, setLocation] = useState(currAccount!.location)
-  const [affiliation, setAffiliation] = useState("")
-  const [favBook, setFavBook] = useState("")
+  const [name, setName] = useState(`${currAccount.fname} ${currAccount.lname}`)
+  const [location, setLocation] = useState(currAccount.location)
+  const [affiliation, setAffiliation] = useState(currAccount.affiliation)
+  const [favBook, setFavBook] = useState(currAccount.affiliation)
+  const [hobbies, setHobbies] = useState(currAccount.hobbies)
   const editProfile = async () => {
     const update = {
       fname: name.split(" ")[0],
       lname: name.split(" ")[1],
       location: location,
+      affiliation: affiliation,
+      favoriteBook: favBook,
+      hobbies: hobbies,
     }
     const newAccount: VolunteerAccount = {
-      ...currAccount!,
+      ...currAccount,
       ...update,
     }
-    const res = await fetch(`/api/volunteeraccounts/${currAccount!.email}`, {
+    const res = await fetch(`/api/volunteeraccounts/${currAccount.email}`, {
       method: "PATCH",
       body: JSON.stringify(update)
     })
@@ -234,204 +257,200 @@ const Profile: NextPage<ProfileProps> = ({ error, broadcasts, account, drives })
     toggleShowEditProfileModal(false)
 
   }
-  if (currAccount) {
-    return (
-      <Grid>
-        <PageContainer broadcasts={broadcasts} fName={currAccount.fname} currPage="profile" />
-        <Grid container display="flex" padding={1} sx={{ pl: 20 }} rowSpacing={2}>
-          <Grid item xs={12} sm={7} display="flex" flexDirection="column" >
-            <Box
-              sx={{
-                width: "100%",
-                height: "175px",
-                border: '1.5px solid black',
+  return (
+    <Grid>
+      <PageContainer broadcasts={broadcasts} fName={currAccount.fname} currPage="profile" />
+      <Grid container display="flex" padding={1} sx={{ pl: 20 }} rowSpacing={2}>
+        <Grid item xs={12} sm={7} display="flex" flexDirection="column" >
+          <Box
+            sx={{
+              width: "100%",
+              height: "175px",
+              border: '1.5px solid black',
+              display: 'flex',
+              marginBottom: '10px',
+              '@media (min-width: 600px)': {
                 display: 'flex',
-                marginBottom: '10px',
-                '@media (min-width: 600px)': {
-                  display: 'flex',
-                  width: '95%',
-                },
-                backgroundColor: "#F5F5F5"
+                width: '95%',
+              },
+              backgroundColor: "#F5F5F5"
+            }}
+          >
+            <div
+              style={{
+                width: '35%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
             >
               <div
                 style={{
-                  width: '35%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "space-between",
+                  borderRadius: 'auto',
+                  width: '50%',
+                  height: 'auto',
                 }}
               >
-                <div
+                <img
+                  src={pfpURL}
+                  alt="Profile Image"
                   style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "space-between",
-                    borderRadius: 'auto',
-                    width: '50%',
-                    height: 'auto',
+                    marginBottom: 20
                   }}
-                >
-                  <img
-                    src={pfpURL}
-                    alt="Profile Image"
-                    style={{
-                      marginBottom: 20
-                    }}
-                  />
-                  <ImageUpload setpfpURL={setpfpURL} currAccount={currAccount} />
-                </div>
+                />
+                <ImageUpload setpfpURL={setpfpURL} currAccount={currAccount} />
               </div>
-              <div
-                style={{
-                  width: '65%',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'flex-start',
-                  paddingLeft: '4px',
-                }}
-              >
-                <p style={{ fontWeight: 800, fontSize: 30, marginBottom: 2, color: "#5F5F5F" }}>{`${currAccount.fname} ${currAccount.lname}`}</p>
-                <p style={{ fontWeight: 500, marginBottom: 2, color: "#5F5F5F" }}>{currAccount.email}</p>
-                <p style={{ fontWeight: 500, color: "#5F5F5F" }}>{`# of Bookdrives completed: ${drives!.length}`}</p>
-                <p style={{ marginTop: 16, color: "#FE9834", fontWeight: 600, cursor: "pointer" }} onClick={() => toggleShowEditProfileModal(true)}>Edit Profile</p>
-              </div>
-
-            </Box>
-            <PersonalInfoCard account={currAccount}/>
-            <BadgeDisplayCase />
-            <dialog
-              ref={editProfileRef}
+            </div>
+            <div
               style={{
-                height: "59%",
-                width: "40%",
-                minWidth: "365px",
-                borderRadius: "3%",
-                padding: 0,
-                position: "absolute",
-                left: "50%",
-                top: "50%",
-                transform: "translate(-50%, -50%)",
+                width: '65%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'flex-start',
+                paddingLeft: '4px',
+              }}
+            >
+              <p style={{ fontWeight: 800, fontSize: 30, marginBottom: 2, color: "#5F5F5F" }}>{`${currAccount.fname} ${currAccount.lname}`}</p>
+              <p style={{ fontWeight: 500, marginBottom: 2, color: "#5F5F5F" }}>{currAccount.email}</p>
+              <p style={{ fontWeight: 500, color: "#5F5F5F" }}>{`# of Bookdrives completed: ${drives!.length}`}</p>
+              <p style={{ marginTop: 16, color: "#FE9834", fontWeight: 600, cursor: "pointer" }} onClick={() => toggleShowEditProfileModal(true)}>Edit Profile</p>
+            </div>
+
+          </Box>
+          <PersonalInfoCard account={currAccount} />
+          <BadgeDisplayCase />
+          <dialog
+            ref={editProfileRef}
+            style={{
+              height: "65%",
+              width: "40%",
+              minWidth: "365px",
+              borderRadius: "3%",
+              padding: 0,
+              position: "absolute",
+              left: "50%",
+              top: "50%",
+              transform: "translate(-50%, -50%)",
+              backgroundColor: "#f5f5f5"
+            }}
+          >
+            <Grid
+              display={"flex"}
+              flexDirection={"column"}
+              justifyContent={"space-between"}
+              alignItems={"center"}
+              alignSelf={"flex-start"}
+              height={"100%"}
+              sx={{
+                backgroundColor: "#F5F5F5",
+                width: "100%",
+                height: "100%",
               }}
             >
               <Grid
-                display={"flex"}
-                flexDirection={"column"}
+                display="flex"
+                flexDirection="row"
+                alignItems="center"
                 justifyContent={"space-between"}
-                alignItems={"center"}
-                alignSelf={"flex-start"}
-                height={"100%"}
-                sx={{
-                  backgroundColor: "#F5F5F5",
-                  width: "100%",
-                  height: "100%",
-                }}
+                width="100%"
+                sx={{ marginTop: 1 }}
               >
-                <Grid
-                  display="flex"
-                  flexDirection="row"
-                  alignItems="center"
-                  justifyContent={"space-between"}
-                  width="100%"
-                  sx={{ marginTop: 1 }}
+                <p
+                  style={{
+                    color: "#5F5F5F",
+                    fontWeight: 600,
+                    fontSize: 20,
+                    width: "90%",
+                    marginLeft: "5%",
+                  }}
                 >
-                  <p
-                    style={{
-                      color: "#5F5F5F",
-                      fontWeight: 600,
-                      fontSize: 20,
-                      width: "90%",
-                      marginLeft: "5%",
-                    }}
-                  >
-                    Edit Profile
-                  </p>
-                  <p style={{ cursor: "pointer", marginRight: 16, fontWeight: "600" }} onClick={() => toggleShowEditProfileModal(false)}>x</p>
+                  Edit Profile
+                </p>
+                <p style={{ cursor: "pointer", marginRight: 16, fontWeight: "600" }} onClick={() => toggleShowEditProfileModal(false)}>x</p>
 
-                </Grid>
-                <div style={{ display: "flex", justifyContent: "space-around", flexDirection: "row", width: "100%", alignItems: "center", }}>
-                  <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "center", width: "40%", }}>
-                    <img src={pfpURL} height={65} />
-                    <ImageUpload setpfpURL={setpfpURL} currAccount={currAccount} />
-                  </div>
-                  <div style={{ display: "flex", flexDirection: "column", width: "60%", height: "100%", justifyContent: "space-around", alignItems: "start", }}>
-                    <i style={{ display: "flex", alignSelf: "flex-start", fontSize: 10 }}>Name</i>
-                    <input type="text" placeholder={"name"} style={{ padding: "3px", width: "90%", height: "30px", fontSize: 16, border: "1px solid #ccc", borderRadius: "4px" }} value={name} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)} />
-                    <i style={{ display: "flex", alignSelf: "flex-start", fontSize: 10 }}>State</i>
-                    <Dropdown options={states} setResult={setLocation} location={location} />
-                  </div>
-                </div>
-                <Grid
-                  display="flex"
-                  flexDirection="column"
-                  justifyContent="space-around"
-                  alignItems="center"
-                  height="wrap-content"
-                  sx={{ width: "100%", padding: 1, }}
-                >
-                  <Button
-                    sx={{
-                      backgroundColor: "#FE9834",
-                      "&:hover": { backgroundColor: "#D87800" },
-                      fontWeight: 550,
-                      color: "white",
-                      width: "95%",
-                      marginBottom: 1
-                    }}
-                    onClick={editProfile}
-                  >
-                    Submit
-                  </Button>
-                  <Button
-                    sx={{
-                      backgroundColor: "#5F5F5F",
-                      "&:hover": { backgroundColor: "#777777" },
-                      fontWeight: 550,
-                      color: "white",
-                      width: "95%"
-                    }}
-                    onClick={() => toggleShowEditProfileModal(false)}
-                  >
-                    Cancel
-                  </Button>
-                </Grid>
               </Grid>
-            </dialog>
-          </Grid>
-          <Grid item xs={12} sm={5} height={"418px"}>
-            <Box
-              sx={{
-                width: "100%",
-                height: "110%",
-                border: "1.5px solid black",
-                '@media (min-width: 600px)': {
-                  display: 'inline-block',
-                  width: '100%',
-                  height: '100%',
-                },
-                maxWidth: "450px",
-                backgroundColor: "#F5F5F5"
-              }}>
-              <MapComponent drives={drives ? drives : []} />
-            </Box>
-          </Grid>
+              <div style={{ display: "flex", justifyContent: "space-around", flexDirection: "row", width: "100%", alignItems: "center", }}>
+                <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "center", width: "40%", }}>
+                  <img src={pfpURL} height={65} />
+                  <ImageUpload setpfpURL={setpfpURL} currAccount={currAccount} />
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", width: "60%", height: "100%", justifyContent: "space-around", alignItems: "start", }}>
+                  <i style={{ marginLeft: 3, display: "flex", alignSelf: "flex-start", fontSize: 10 }}>Name</i>
+                  <input type="text" placeholder={"name"} style={{ padding: "3px", width: "93%", height: "30px", fontSize: 16, border: "1px solid #ccc", borderRadius: "4px" }} value={name} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)} />
+                  <i style={{ marginLeft: 3, display: "flex", alignSelf: "flex-start", fontSize: 10 }}>State</i>
+                  <Dropdown options={states} setResult={setLocation} location={location} />
+                </div>
+              </div>
+              <div style={{ display: "flex", flex: 1, minHeight: 170, paddingTop: 5, paddingBottom: 5, justifyContent: "space-around", flexDirection: "column", width: "100%", alignItems: "start", paddingLeft: "4%" }}>
+                <i style={{ marginLeft: 3, fontSize: 10 }}>Affiliation</i>
+                <input style={{ padding: 3, width: "96%", height: "30px", fontSize: 16, border: "1px solid #ccc", borderRadius: "4px" }} type="text" onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAffiliation(e.target.value)} value={affiliation} />
+                <i style={{ marginLeft: 3, fontSize: 10 }}>Hobbies</i>
+                <input style={{ padding: 3, width: "96%", height: "30px", fontSize: 16, border: "1px solid #ccc", borderRadius: "4px" }} type="text" onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHobbies(e.target.value.split(", "))} value={hobbies.join(", ")} />
+                <i style={{ marginLeft: 3, fontSize: 10 }}>Favorite Book</i>
+                <input style={{ padding: 3, width: "96%", height: "30px", fontSize: 16, border: "1px solid #ccc", borderRadius: "4px" }} type="text" onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFavBook(e.target.value)} value={favBook} />
+              </div>
+              <Grid
+                display="flex"
+                flexDirection="column"
+                justifyContent="space-around"
+                alignItems="center"
+                height="wrap-content"
+                sx={{ width: "100%", padding: 1, }}
+              >
+                <Button
+                  sx={{
+                    backgroundColor: "#FE9834",
+                    "&:hover": { backgroundColor: "#D87800" },
+                    fontWeight: 550,
+                    color: "white",
+                    width: "95%",
+                    marginBottom: 1
+                  }}
+                  onClick={editProfile}
+                >
+                  Submit
+                </Button>
+                <Button
+                  sx={{
+                    backgroundColor: "#5F5F5F",
+                    "&:hover": { backgroundColor: "#777777" },
+                    fontWeight: 550,
+                    color: "white",
+                    width: "95%"
+                  }}
+                  onClick={() => toggleShowEditProfileModal(false)}
+                >
+                  Cancel
+                </Button>
+              </Grid>
+            </Grid>
+          </dialog>
+        </Grid>
+        <Grid item xs={12} sm={5} height={"418px"}>
+          <Box
+            sx={{
+              width: "100%",
+              height: "110%",
+              border: "1.5px solid black",
+              '@media (min-width: 600px)': {
+                display: 'inline-block',
+                width: '100%',
+                height: '100%',
+              },
+              maxWidth: "450px",
+              backgroundColor: "#F5F5F5"
+            }}>
+            <MapComponent drives={drives ? drives : []} />
+          </Box>
         </Grid>
       </Grid>
-    )
-  }
-  else {
-    return (
-      <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "100px", flexDirection: "column" }}>
-        <h1>{error}</h1>
-        {// when the error is not an auth error give them the button to go back
-          error !== "You must login before accessing this page" &&
-          <Link href="/dash-volunteer">
-            <button style={{ width: "50px", height: "50px", borderRadius: "20%" }}>Volunteer Dashboard</button>
-          </Link>}
-      </div>
-    )
-  }
+    </Grid>
+  )
+
 }
 
 export const getServerSideProps = async (context: any) => {


### PR DESCRIPTION
![image](https://github.com/Hack4Impact-Princeton/alp-portal/assets/113332215/3ccf1b27-86fc-41bf-be32-536ea68183fa)

Added support for affiliation, hobbies, and favorite book editing. Added check to make sure that the name must have at least two words.

- caveats: you add hobbies not as shown in the figma where you search and add from a drag and drop, but instead, you just write a string where each hobby is separated by a comma

to replicate:
- go to test4@test.com and edit each field individually, all at once - make sure that the edits appear. 
     - for editing hobbies, affiliations, favbook, you should be able to leave the field blank and that's a successful edit
     - you shouldn't be able to leave name blank, nor should you be able to have a one-word name. 
     - start editing fields, but don't hit submit - hit the x or the cancel button. The edits shouldn't show on the page and when you reopen the modal, they shouldn't show either